### PR TITLE
isFullyCalibrated() depends on the sensor mode

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -612,9 +612,27 @@ bool Adafruit_BNO055::isFullyCalibrated(void)
 {
     uint8_t system, gyro, accel, mag;
     getCalibration(&system, &gyro, &accel, &mag);
-    if (system < 3 || gyro < 3 || accel < 3 || mag < 3)
-        return false;
-    return true;
+    
+    switch(_mode)
+    {
+      case OPERATION_MODE_ACCONLY:
+        return (accel==3);
+      case OPERATION_MODE_MAGONLY:
+        return (mag==3);
+      case OPERATION_MODE_GYRONLY:
+      case OPERATION_MODE_M4G: /* No magnetometer calibration required. */
+        return (gyro==3);
+      case OPERATION_MODE_ACCMAG:
+      case OPERATION_MODE_COMPASS:
+        return (accel==3 && mag==3);
+      case OPERATION_MODE_ACCGYRO:
+      case OPERATION_MODE_IMUPLUS:
+        return (accel==3 && gyro==3);
+      case OPERATION_MODE_MAGGYRO:
+        return (mag==3 && gyro==3);
+      default:
+        return (system==3 && gyro==3 && accel==3 && mag==3);
+    }
 }
 
 


### PR DESCRIPTION
Depending on the mode, full calibration can be achieved, before
all sensor types are calibrated. E.g. OPERATION_MODE_IMUPLUS requires
only the gyro and the accelerometer.

Before the user could only obtain sensor offsets, when all sensors
were calibrated. For most modes this is not required.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
